### PR TITLE
feat(database): add composite indexes for query optimization

### DIFF
--- a/pkg/dbinit/migrations/20250704000001_add_composite_indexes.sql
+++ b/pkg/dbinit/migrations/20250704000001_add_composite_indexes.sql
@@ -1,0 +1,30 @@
+-- migrate:up
+
+-- Primary composite index for folder navigation queries
+-- Benefits: ListS3Objects, ListS3Folders, ListS3Files, CountS3Objects,
+--           CountDirectChildrenFolders, CountDirectChildrenFiles, GetDirectChildren
+-- This index uses PostgreSQL's "leftmost prefix" rule, so it can be used for:
+--   - bucket_id only
+--   - bucket_id + prefix
+--   - bucket_id + prefix + is_folder (optimal)
+CREATE INDEX idx_s3_objects_bucket_prefix_folder
+  ON s3_objects(bucket_id, prefix, is_folder);
+
+-- Secondary composite index for breadcrumb navigation
+-- Benefits: GetBreadcrumbPath query (finds all parent folders in a path)
+CREATE INDEX idx_s3_objects_bucket_folder
+  ON s3_objects(bucket_id, is_folder);
+
+-- Partial index for deletion sync queries
+-- Benefits: DeleteMarkedObjects (only indexes rows marked for deletion)
+-- This partial index is much smaller and faster than a full index
+CREATE INDEX idx_s3_objects_bucket_deletion
+  ON s3_objects(bucket_id, marked_for_deletion)
+  WHERE marked_for_deletion = TRUE;
+
+-- migrate:down
+
+-- Drop indexes in reverse order of creation
+DROP INDEX IF EXISTS idx_s3_objects_bucket_deletion;
+DROP INDEX IF EXISTS idx_s3_objects_bucket_folder;
+DROP INDEX IF EXISTS idx_s3_objects_bucket_prefix_folder;


### PR DESCRIPTION
Add three composite indexes to s3_objects table to optimize query performance:

- idx_s3_objects_bucket_prefix_folder: optimizes 7 major queries including
  ListS3Objects, ListS3Folders, ListS3Files, and count operations
- idx_s3_objects_bucket_folder: optimizes breadcrumb navigation queries
- idx_s3_objects_bucket_deletion: partial index for deletion sync

These indexes eliminate multiple single-column index lookups and enable
PostgreSQL to use optimal query plans for bucket-based filtering.

Fixes #75