### PR TITLE
feat(database): add configurable connection pool settings

### DIFF
--- a/conf-examples/config-aws-sso.yaml
+++ b/conf-examples/config-aws-sso.yaml
@@ -22,6 +22,11 @@ s3:
 # Database Configuration
 database:
   url: "postgres://postgres:postgres@localhost:5432/s3xplorer?sslmode=disable"
+  # Connection pool settings (optional, defaults shown below)
+  # max_open_conns: 25          # Maximum concurrent database connections
+  # max_idle_conns: 5           # Idle connections to keep alive
+  # conn_max_lifetime: "5m"     # Maximum connection lifetime
+  # conn_max_idle_time: "1m"    # Maximum idle time before closing
 
 # Background Scanning Configuration
 scan:

--- a/conf-examples/config-minio.yaml
+++ b/conf-examples/config-minio.yaml
@@ -22,6 +22,11 @@ s3:
 # Database Configuration
 database:
   url: "postgres://postgres:postgres@localhost:5432/s3xplorer?sslmode=disable"
+  # Connection pool settings (optional, defaults shown below)
+  # max_open_conns: 25          # Maximum concurrent database connections
+  # max_idle_conns: 5           # Idle connections to keep alive
+  # conn_max_lifetime: "5m"     # Maximum connection lifetime
+  # conn_max_idle_time: "1m"    # Maximum idle time before closing
 
 # Background Scanning Configuration
 scan:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,7 +31,11 @@ type S3Config struct {
 
 // DatabaseConfig contains database-related configuration.
 type DatabaseConfig struct {
-	URL string `yaml:"url"`
+	URL              string `yaml:"url"`
+	MaxOpenConns     int    `yaml:"max_open_conns"`
+	MaxIdleConns     int    `yaml:"max_idle_conns"`
+	ConnMaxLifetime  string `yaml:"conn_max_lifetime"`
+	ConnMaxIdleTime  string `yaml:"conn_max_idle_time"`
 }
 
 // ScanConfig contains scanning-related configuration.
@@ -107,7 +111,21 @@ func (c *Config) setDefaults() {
 	if c.Database.URL == "" {
 		c.Database.URL = "postgres://postgres:postgres@localhost:5432/s3xplorer?sslmode=disable"
 	}
-	
+
+	// Set default database pool settings
+	if c.Database.MaxOpenConns == 0 {
+		c.Database.MaxOpenConns = 25
+	}
+	if c.Database.MaxIdleConns == 0 {
+		c.Database.MaxIdleConns = 5
+	}
+	if c.Database.ConnMaxLifetime == "" {
+		c.Database.ConnMaxLifetime = "5m"
+	}
+	if c.Database.ConnMaxIdleTime == "" {
+		c.Database.ConnMaxIdleTime = "1m"
+	}
+
 	// Set default bucket sync configuration
 	if c.BucketSync.SyncThreshold == "" {
 		c.BucketSync.SyncThreshold = "24h" // Mark as inaccessible after 24 hours

--- a/s3xplorer.go
+++ b/s3xplorer.go
@@ -121,7 +121,7 @@ func initInfrastructure(ctx context.Context, cfg configapp.Config, l *slog.Logge
 		return nil, nil, fmt.Errorf("error initializing S3 client: %w", err)
 	}
 
-	dbConn, err := dbinit.InitializeDatabase(ctx, cfg.Database.URL, l)
+	dbConn, err := dbinit.InitializeDatabase(ctx, cfg.Database, l)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error initializing database: %w", err)
 	}


### PR DESCRIPTION
Add configurable database connection pool settings to prevent connection
exhaustion and improve resource utilization for concurrent web traffic
and background scanning operations.

Changes:
- Extend DatabaseConfig struct with pool configuration fields:
  - max_open_conns: Maximum concurrent database connections (default: 25)
  - max_idle_conns: Idle connections to keep alive (default: 5)
  - conn_max_lifetime: Maximum connection lifetime (default: 5m)
  - conn_max_idle_time: Maximum idle time before closing (default: 1m)
- Apply pool settings in openAndTestConnection after sql.Open()
- Update InitializeDatabase to accept full DatabaseConfig instead of URL
- Document pool settings in example config files with defaults
- Add structured logging for pool configuration

Pool settings are optional and use sensible defaults. Users can override
via YAML configuration for different deployment scenarios.

Fixes #77